### PR TITLE
Scale grid based on view-min to fit better

### DIFF
--- a/src/components/Grid.styles.js
+++ b/src/components/Grid.styles.js
@@ -5,8 +5,8 @@ export default createUseStyles({
     display: 'grid',
     gridTemplateRows: 'repeat(5, 1fr)',
     gridTemplateColumns: 'repeat(8, 1fr)',
-    width: '80vw',
-    height: '50vw',
+    width: '80vmin',
+    height: '50vmin',
     border: '2px solid black',
   },
   cell: {


### PR DESCRIPTION
The original values put the color selector and command result out of view and unreachable. Now the overall is smaller but more dynamic.

# Before:
![image](https://user-images.githubusercontent.com/7132646/91453927-f5a77000-e845-11ea-9645-c5e2a3540f74.png)
![image](https://user-images.githubusercontent.com/7132646/91453951-fd671480-e845-11ea-94db-28b2ec487c53.png)
# After:
![image](https://user-images.githubusercontent.com/7132646/91453838-d6a8de00-e845-11ea-9580-5ddbf075db78.png)
![image](https://user-images.githubusercontent.com/7132646/91453869-de688280-e845-11ea-97a0-ad3e8b313a5d.png)
