### PR TITLE
Modify the the chatString's format

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,17 @@ function App() {
     [cells]
   );
   const chatString = useMemo(
-    () => cells.map((cell) => cell.color.slice(1)).join(','),
+    () =>
+      JSON.stringify(
+        cells
+          .map((cell) => cell.color.slice(1))
+          .reduce((acc, color, i) => {
+            if (parseInt(color, 10) !== 0) {
+              acc[`${parseInt(i / 5, 10)}${parseInt(i, 10) % 5}`] = color;
+            }
+            return acc;
+          }, {})
+      ),
     [cells]
   );
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ function App() {
           .map((cell) => cell.color.slice(1))
           .reduce((acc, color, i) => {
             if (parseInt(color, 10) !== 0) {
-              acc[`${parseInt(i / 5, 10)}${parseInt(i, 10) % 5}`] = color;
+              acc[`${parseInt(i / 8, 10)}${parseInt(i, 10) % 8}`] = color;
             }
             return acc;
           }, {})


### PR DESCRIPTION
Instead of joining all of the colors with a comma, I made the changes so the output string is an JSON object, stringified, where the keys are the indexes of the cell, in a 2D array.
For example, instead of returning ```!rgb 000000,56BC58,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,56BC58,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,000000,56BC58,000000```, it returns ```!rgb {"14":"56BC58","46":"56BC58","01":"56BC58"}```