### PR TITLE
Addded !rgb command compression.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,33 @@ import Grid from './components/Grid';
 import ColorPicker from './components/ColorPicker';
 import useStyles from './App.styles';
 
+//  A custom function to do a kinda-dict based compression.
+function smallify(command) {
+  let colours;
+  //  Allows for direct passing of a !rgb command or an array of colours.
+  if (typeof command === 'string') {
+    colours = command.split(/[ ,]/g);
+  } else colours = command;
+  if (colours[0].startsWith('!')) colours.shift();
+  const firsts = new Map();
+  let next = 0;
+  return colours
+    .reduce((res, colour) => {
+      //  Check if this colour has been specified. If it has use the index of the first occurance as it is garunteed to be shorter.
+      let outPart = '';
+      if (firsts.has(colour)) {
+        outPart += `*${firsts.get(colour).toString(16)}`;
+      } else {
+        //  Otherwise just ad the raw colour and save this as the first occurance.
+        outPart += colour;
+        firsts.set(colour, next);
+        next += 1;
+      }
+      return `${res}${outPart},`;
+    }, '!rgb ')
+    .slice(0, -1);
+}
+
 const offCell = {
   on: false,
   color: '#000000',
@@ -23,7 +50,7 @@ function App() {
     [cells]
   );
   const chatString = useMemo(
-    () => cells.map((cell) => cell.color.slice(1)).join(','),
+    () => smallify(cells.map((cell) => cell.color.slice(1))),
     [cells]
   );
   return (
@@ -40,12 +67,7 @@ function App() {
         ))}
       </div>
       <Grid cells={cells} setCells={setCells} currentColor={currentColor} />
-      <p className={classes.chatString}>
-        {/* eslint-disable-next-line */}
-        !rgb
-        {' '}
-        {chatString}
-      </p>
+      <p className={classes.chatString}>{chatString}</p>
     </div>
   );
 }


### PR DESCRIPTION
Added compression to the `!rgb` command. Repeated colours will instead use a back-reference `*f` where `f` refers to the 15th unique colour in the piece.

e.g.
`!rgb ff0000,00ff00,ff0000,00ff00`
would get encoded as:
`!rgb ff0000,00ff00,*0,*1`

A more complex example:
`!rgb ff0000,00ff00,ff00ff,0000ff,00ff00,ff0000,0000ff`
becomes:
`!rgb ff0000,00ff00,*0,0000ff,*1,*0,*2`

The mirrored request for rgb-led-matrix that accepts this format can be found [here](https://github.com/CodingGarden/rgb-led-matrix/pull/2#issue-477972866)